### PR TITLE
[DREAMSTORE V1 ONLY] Account/Orders hack

### DIFF
--- a/pages/pages.json
+++ b/pages/pages.json
@@ -225,5 +225,10 @@
         "template": "product"
       }
     ]
+  },
+  "routes": {
+    "store/account": {
+      "path": "/account/orders"
+    }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Small hack to make the dreamstore redirect correctly the path `/account/orders` to the account app.

DISCLAIMER: This fix will only work on the dreamstore v1, this problem is already been addressed on the version 2.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
