### PR TITLE
Define blocks of orderPlaced page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.2.2] - 2019-05-02
 - Add `store.orderplaced` block definition to `blocks.json`.
 
 ## [2.2.1] - 2019-03-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add `store.orderplaced` block definition to `blocks.json`.
 
 ## [2.2.1] - 2019-03-18
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-theme",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "builders": {
     "styles": "1.x",
     "store": "0.x"

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -50,6 +50,16 @@
       "login-content#default"
     ]
   },
+  "store.orderplaced": {
+    "blocks": [
+      "order-placed"
+    ]
+  },
+  "header": {
+    "blocks": [
+      "logo"
+    ]
+  },
   "header.full": {
     "blocks": [
       "login",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Define blocks of orderPlaced page (and normal header)

#### What problem is this solving?

If store.orderplaced is not referenced in store-theme's blocks.json, the header and footer on that page do not inherit the props set by store-theme, resulting in an empty and/or unthemed header and footer. Defining the blocks in blocks.json solves this.

#### How should this be manually tested?

Navigate to /checkout/orderPlaced and verify that the footer matches the footer on the homepage.

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
