### PR TITLE
Add labelListPrice props in product-details and summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `labelListPrice` in product-details and summary blocks.
 
 ## [2.3.1] - 2019-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.4.0] - 2019-05-09
 ### Added
 - Add `labelListPrice` in product-details and summary blocks.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-theme",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "builders": {
     "styles": "1.x",
     "store": "0.x"

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -232,6 +232,8 @@
           "buyButtonText": "Comprar",
           "displayBuyButton": "displayButtonHover",
           "showCollections": false,
+          "labelListPrice": null,
+          "labelSellingPrice": null,
           "showListPrice": true,
           "showLabels": false,
           "showInstallments": true,
@@ -270,6 +272,7 @@
         }
       },
       "price": {
+        "labelListPrice": null,
         "labelSellingPrice": null,
         "showListPrice": true,
         "showLabels": true,
@@ -313,6 +316,7 @@
         "showBadge": true,
         "displayBuyButton": "displayButtonAlways",
         "showCollections": false,
+        "labelListPrice": null,
         "labelSellingPrice": null,
         "showListPrice": true,
         "showLabels": true,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the `labelListPrice` in the *product-details* and *summary* blocks to permit [these](https://github.com/vtex-apps/store-components/pull/441) changes.

<!--- Describe your changes in detail. -->

#### What problem is this solving?
Discount price labels should be flexible and changed in the blocks file.


#### How should this be manually tested?
[Workspace](https://rubacao--storecomponents.myvtex.com/traveler-backpack/p?disableUserLand)

If you want to see other behaviors, edit the blocks in store-theme and use the flag ?disableUserLand in the url.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
