### PR TITLE
Feature/new layout/no categories

### DIFF
--- a/store/blocks.json
+++ b/store/blocks.json
@@ -155,7 +155,7 @@
       "highlight": false,
       "itemProps": {
         "type": "internal",
-        "href": "#",
+        "href": "/clothing/d",
         "noFollow": true,
         "tagTitle": "Clothing",
         "text": "Clothing"
@@ -192,7 +192,7 @@
       "highlight": false,
       "itemProps": {
         "type": "internal",
-        "href": "#",
+        "href": "/hats/d",
         "noFollow": true,
         "tagTitle": "Hats",
         "text": "Hats"
@@ -207,7 +207,7 @@
       "highlight": false,
       "itemProps": {
         "type": "internal",
-        "href": "#",
+        "href": "/shoes/d",
         "noFollow": true,
         "tagTitle": "Shoes",
         "text": "Shoes"
@@ -222,7 +222,7 @@
       "highlight": false,
       "itemProps": {
         "type": "internal",
-        "href": "#",
+        "href": "/bags/d",
         "noFollow": true,
         "tagTitle": "Bags",
         "text": "Bags"
@@ -237,7 +237,7 @@
       "highlight": false,
       "itemProps": {
         "type": "internal",
-        "href": "#",
+        "href": "/accessories/d",
         "noFollow": true,
         "tagTitle": "Accessories",
         "text": "Accessories"
@@ -252,7 +252,7 @@
       "highlight": false,
       "itemProps": {
         "type": "internal",
-        "href": "#",
+        "href": "/decoration/d",
         "noFollow": true,
         "tagTitle": "Decoration",
         "text": "Decoration"
@@ -267,7 +267,7 @@
       "highlight": false,
       "itemProps": {
         "type": "internal",
-        "href": "#",
+        "href": "/notebooks/d",
         "noFollow": true,
         "tagTitle": "Notebooks",
         "text": "Notebooks"
@@ -282,7 +282,7 @@
       "highlight": false,
       "itemProps": {
         "type": "internal",
-        "href": "#",
+        "href": "/sale/d",
         "noFollow": true,
         "tagTitle": "Sale",
         "text": "Sale"
@@ -504,8 +504,9 @@
       "isFullModeStyle": false,
       "textPosition": "left",
       "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/banner-infocard2.png",
-      "headline": "Example of a call to action text",
+      "headline": "Clearance Sale",
       "callToActionText": "DISCOVER",
+      "callToActionUrl": "/sale/d",
       "blockClass": "info-card-home"
     }
   },

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -393,11 +393,11 @@
           "mobileImage": "https://storecomponents.vteximg.com.br/arquivos/banner-principal-mobile.jpg"
         },
         {
-          "image": "https://storecomponents.vteximg.com.br/arquivos/banner-principal.png",
+          "image": "https://storecomponents.vteximg.com.br/assets/vtex.file-manager-graphql/images/banner-black___6b3a762f6c60ed998b74c4114541b9d0.png",
           "mobileImage": "https://storecomponents.vteximg.com.br/arquivos/banner-principal-mobile.jpg"
         }
       ],
-      "height": 640,
+      "height": 500,
       "showArrows": true,
       "showDots": true
     }
@@ -624,24 +624,246 @@
       }
     }
   },
-  "vtex.menu@2.x:menu#footer-clothing": {
-    "props": {
-      "categoryId": 16,
-      "orientation": "vertical"
-    }
-  },
   "vtex.menu@2.x:menu#footer-decoration": {
     "props": {
-      "categoryId": 2,
       "orientation": "vertical"
+    },
+    "children": [
+      "menu-item#smartphones",
+      "menu-item#videogames",
+      "menu-item#tvs"
+    ]
+  },
+
+  "menu-item#smartphones": {
+    "props": {
+      "id": "menu-item-smartphones",
+      "type": "custom",
+      "iconId": null,
+      "highlight": false,
+      "itemProps": {
+        "type": "internal",
+        "href": "/decoration/smartphones",
+        "noFollow": true,
+        "tagTitle": "Smartphones",
+        "text": "Smartphones"
+      }
     }
   },
+
+  "menu-item#videogames": {
+    "props": {
+      "id": "menu-item-videogames",
+      "type": "custom",
+      "iconId": null,
+      "highlight": false,
+      "itemProps": {
+        "type": "internal",
+        "href": "/decoration/videogames",
+        "noFollow": true,
+        "tagTitle": "Videogames",
+        "text": "Videogames"
+      }
+    }
+  },
+
+
+  "menu-item#tvs": {
+    "props": {
+      "id": "menu-item-tvs",
+      "type": "custom",
+      "iconId": null,
+      "highlight": false,
+      "itemProps": {
+        "type": "internal",
+        "href": "/decoration/tvs",
+        "noFollow": true,
+        "tagTitle": "TVs",
+        "text": "TVs"
+      }
+    }
+  },
+
+
   "vtex.menu@2.x:menu#footer-bags": {
     "props": {
-      "categoryId": 11,
       "orientation": "vertical"
+    },
+    "children": [
+      "menu-item#bags",
+      "menu-item#backpacks",
+      "menu-item#necessaire"
+    ]
+  },
+
+
+
+  "menu-item#bags": {
+    "props": {
+      "id": "menu-item-bags",
+      "type": "custom",
+      "iconId": null,
+      "highlight": false,
+      "itemProps": {
+        "type": "internal",
+        "href": "/bags/d",
+        "noFollow": true,
+        "tagTitle": "Bags",
+        "text": "Bags"
+      }
     }
   },
+
+
+  "menu-item#backpacks": {
+    "props": {
+      "id": "menu-item-backpacks",
+      "type": "custom",
+      "iconId": null,
+      "highlight": false,
+      "itemProps": {
+        "type": "internal",
+        "href": "/bags/backpacks",
+        "noFollow": true,
+        "tagTitle": "Backpacks",
+        "text": "Backpacks"
+      }
+    }
+  },
+
+
+
+  "menu-item#necessaire": {
+    "props": {
+      "id": "menu-item-necessaire",
+      "type": "custom",
+      "iconId": null,
+      "highlight": false,
+      "itemProps": {
+        "type": "internal",
+        "href": "/bags/necessaire",
+        "noFollow": true,
+        "tagTitle": "Necessaire",
+        "text": "Necessaire"
+      }
+    }
+  },
+
+
+
+  "vtex.menu@2.x:menu#footer-clothing": {
+    "props": {
+      "orientation": "vertical"
+    },
+    "children": [
+      "menu-item#clothing",
+      "menu-item#shorts",
+      "menu-item#tank-tops",
+      "menu-item#shirts",
+      "menu-item#sweatshirt",
+      "menu-item#cropped"
+    ]
+  },
+
+
+  "menu-item#clothing": {
+    "props": {
+      "id": "menu-item-category-clothing",
+      "type": "custom",
+      "iconId": null,
+      "highlight": false,
+      "itemProps": {
+        "type": "internal",
+        "href": "/clothing/d",
+        "noFollow": true,
+        "tagTitle": "Clothing",
+        "text": "Clothing"
+      }
+    }
+  },
+
+  "menu-item#shorts": {
+    "props": {
+      "id": "menu-item-shorts",
+      "type": "custom",
+      "iconId": null,
+      "highlight": false,
+      "itemProps": {
+        "type": "internal",
+        "href": "/clothing/shorts",
+        "noFollow": false,
+        "tagTitle": "Shorts",
+        "text": "Shorts"
+      }
+    }
+  },
+
+  "menu-item#tank-tops": {
+    "props": {
+      "id": "menu-item-tank-tops",
+      "type": "custom",
+      "iconId": null,
+      "highlight": false,
+      "itemProps": {
+        "type": "internal",
+        "href": "/clothing/tank-tops",
+        "noFollow": false,
+        "tagTitle": "Tank tops",
+        "text": "Tank tops"
+      }
+    }
+  },
+
+  "menu-item#shirts": {
+    "props": {
+      "id": "menu-item-shirts",
+      "type": "custom",
+      "iconId": null,
+      "highlight": false,
+      "itemProps": {
+        "type": "internal",
+        "href": "/clothing/shirts",
+        "noFollow": false,
+        "tagTitle": "Shirts",
+        "text": "Shirts"
+      }
+    }
+  },
+
+  "menu-item#sweatshirt": {
+    "props": {
+      "id": "menu-item-sweat-shirts",
+      "type": "custom",
+      "iconId": null,
+      "highlight": false,
+      "itemProps": {
+        "type": "internal",
+        "href": "/clothing/sweatshirt",
+        "noFollow": false,
+        "tagTitle": "Sweatshirt",
+        "text": "Sweatshirt"
+      }
+    }
+  },
+
+
+
+  "menu-item#cropped": {
+    "props": {
+      "id": "menu-item-cropped",
+      "type": "custom",
+      "iconId": null,
+      "highlight": false,
+      "itemProps": {
+        "type": "internal",
+        "href": "/clothing/cropped",
+        "noFollow": false,
+        "tagTitle": "Cropped",
+        "text": "Cropped"
+      }
+    }
+  },
+
   "social-networks": {
     "props": {
       "socialNetworks": [
@@ -924,4 +1146,3 @@
     }
   }
 }
-

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -150,11 +150,15 @@
   "menu-item#category-clothing": {
     "props": {
       "id": "menu-item-category-clothing",
-      "type": "category",
+      "type": "custom",
       "iconId": null,
       "highlight": false,
       "itemProps": {
-        "categoryId": 16
+        "type": "internal",
+        "href": "#",
+        "noFollow": true,
+        "tagTitle": "Clothing",
+        "text": "Clothing"
       }
     },
     "blocks": [
@@ -183,66 +187,90 @@
   "menu-item#category-clothing-hats": {
     "props": {
       "id": "menu-item-category-clothing-hats",
-      "type": "category",
+      "type": "custom",
       "iconId": null,
       "highlight": false,
       "itemProps": {
-        "categoryId": 16
+        "type": "internal",
+        "href": "#",
+        "noFollow": true,
+        "tagTitle": "Hats",
+        "text": "Hats"
       }
     }
   },
   "menu-item#category-clothing-shoes": {
     "props": {
       "id": "menu-item-category-clothing-hats",
-      "type": "category",
+      "type": "custom",
       "iconId": null,
       "highlight": false,
       "itemProps": {
-        "categoryId": 10
+        "type": "internal",
+        "href": "#",
+        "noFollow": true,
+        "tagTitle": "Shoes",
+        "text": "Shoes"
       }
     }
   },
   "menu-item#category-clothing-bags": {
     "props": {
       "id": "menu-item-category-clothing-hats",
-      "type": "category",
+      "type": "custom",
       "iconId": null,
       "highlight": false,
       "itemProps": {
-        "categoryId": 11
+        "type": "internal",
+        "href": "#",
+        "noFollow": true,
+        "tagTitle": "Bags",
+        "text": "Bags"
       }
     }
   },
   "menu-item#category-clothing-accessories": {
     "props": {
       "id": "menu-item-category-clothing-hats",
-      "type": "category",
+      "type": "custom",
       "iconId": null,
       "highlight": false,
       "itemProps": {
-        "categoryId": 25
+        "type": "internal",
+        "href": "#",
+        "noFollow": true,
+        "tagTitle": "Accessories",
+        "text": "Accessories"
       }
     }
   },
   "menu-item#category-decoration": {
     "props": {
       "id": "menu-item-category-decoration",
-      "type": "category",
+      "type": "custom",
       "iconId": null,
       "highlight": false,
       "itemProps": {
-        "categoryId": 2
+        "type": "internal",
+        "href": "#",
+        "noFollow": true,
+        "tagTitle": "Decoration",
+        "text": "Decoration"
       }
     }
   },
   "menu-item#category-notebooks": {
     "props": {
       "id": "menu-item-category-notebooks",
-      "type": "category",
+      "type": "custom",
       "iconId": null,
       "highlight": false,
       "itemProps": {
-        "categoryId": 26
+        "type": "internal",
+        "href": "#",
+        "noFollow": true,
+        "tagTitle": "Notebooks",
+        "text": "Notebooks"
       }
     }
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Current reference to category ids is not compatible with every account. 

The idea of the store theme is to allow anyone to clone it and learn how to use our blocks. With the limitation of the category ids, it is currently not possible.

#### What problem is this solving?

I've removed the category ids by changing the menu-items type to ``custom``.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
