### PR TITLE
Show the heart icon of wish list in product details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Show the heart icon of wish list in product details.
 
 ## [3.5.0] - 2019-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.5.1] - 2019-06-12
 ### Fixed
 - Show the heart icon of wish list in product details.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-theme",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "builders": {
     "styles": "1.x",
     "store": "0.x"

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1015,6 +1015,7 @@
       "width": "60%"
     },
     "children": [
+      "product-addon-wrapper",
       "product-images"
     ]
   },

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1012,7 +1012,8 @@
   },
   "flex-layout.col#product-image": {
     "props": {
-      "width": "60%"
+      "width": "60%",
+      "rowGap": 0
     },
     "children": [
       "product-addon-wrapper",

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1016,7 +1016,7 @@
       "rowGap": 0
     },
     "children": [
-      "product-addon-wrapper",
+      "product-add-to-list-button",
       "product-images"
     ]
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Show the heart icon of wish list in product details.

#### What problem is this solving?

In product details screen doesn't show the heart icon to add product in wish list.

### How should this be manually tested?

[workspace](https://thaynan--storecomponents.myvtex.com/)

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
