### PR TITLE
Add product review form page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add product-review-form block to avoid falling back to the default layout.
 
 ## [3.7.1] - 2019-07-26
 ### Changed

--- a/store/blocks.jsonc
+++ b/store/blocks.jsonc
@@ -1,6 +1,6 @@
 /* Blocks can be defined both on the store/blocks.json file, and in any number of json
  * files inside the store/blocks directory, with any arbitrary directory structure.
- * 
+ *
  * Additionally, all blocks files can support comments, such as this one, if given the
  * .jsonc file extension.
  *
@@ -9,24 +9,18 @@
  */
 {
   "store.orderplaced": {
-   "blocks":[
-     "order-placed"
-    ]
+    "blocks": ["order-placed"]
   },
 
   "store.account": {
-    "blocks": [
-      "my-account"
-    ],
+    "blocks": ["my-account"],
     "parent": {
       "challenge": "challenge.profile"
     }
   },
 
   "store.login": {
-    "blocks": [
-      "login-content#default"
-    ]
+    "blocks": ["login-content#default"]
   },
 
   "login-content#default": {
@@ -48,5 +42,9 @@
       "product-identifier.summary",
       "product-summary-buy-button"
     ]
+  },
+
+  "store.product-review-form": {
+    "blocks": ["product-review-form"]
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

Product review apps were showing the product review form page as the default layout. The theme should define those pages so it doesn't falls back to the default header and footer of the store.

#### How should this be manually tested?

[Workspace](https://breno3--storecomponents.myvtex.com/new-review)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

n/a

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
