### PR TITLE
Feature/display thumbnails arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `displayThumbnailsArrows` to the `product-images` block.
 
 ## [3.6.1] - 2019-07-17
 ### Changed

--- a/store/blocks/product.json
+++ b/store/blocks/product.json
@@ -40,6 +40,11 @@
       "product-images"
     ]
   },
+  "product-images": {
+    "props": {
+      "displayThumbnailsArrows": true
+    }
+  },
   "flex-layout.col#product-price": {
     "props": {
       "preventVerticalStretch": true,


### PR DESCRIPTION
#### What problem is this solving?
Adds `displayThumbnailsArrows` to the `product-images` block. (https://github.com/vtex-apps/store-components/pull/531)

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
