### PR TITLE
Remove usage of deprecated selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove usage of deprecated selectors.
 
 ## [3.17.0] - 2019-11-06
 ### Changed

--- a/styles/css/vtex.carousel.css
+++ b/styles/css/vtex.carousel.css
@@ -2,6 +2,6 @@
   background-color: #F0F0F0;
 }
 
-.containerImg img {
+.containerImg .img {
   max-width: 1520px;
 }

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -34,24 +34,22 @@
 
 .inputGroup {
   padding-bottom: 4px;
-  border-bottom: 2px solid #fff;
   display: flex;
   color: #fff;
 }
 
-.inputGroup input {
+.inputGroup :global(.vtex-styleguide-9-x-hideDecorators) {
   background-color: transparent;
   color: #fff;
   border: none;
-  padding-left: 0px;
 }
 
-.inputGroup input::placeholder {
+.inputGroup :global(.vtex-styleguide-9-x-hideDecorators)::placeholder {
   color: #fff;
   font-size: 16px;
 }
 
-.inputGroup button {
+.inputGroup :global(.vtex-button) {
   background-color: transparent;
   color: #fff;
   border: none;


### PR DESCRIPTION
#### What problem is this solving?

Solve warning of deprecation messages of the [CSS Selectors release](https://vtex.io/docs/releases/2019-week-43-44/css-selectors-deprecation?utm_source=pr).

#### How should this be manually tested?

[Workspace](https://breno--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
