### PR TITLE
Use the proper API to space sku selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use the proper API to space SKU Selector
 
 ## [3.18.0] - 2019-11-11
 ### Fixed

--- a/store/blocks/product.json
+++ b/store/blocks/product.json
@@ -87,6 +87,12 @@
     ]
   },
 
+  "sku-selector": {
+    "props": {
+      "variationsSpacing": 3
+    }
+  },
+
   "product-price#product-details": {
     "props": {
       "showInstallments": true,

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -69,10 +69,6 @@
   margin: 1rem 0;
 }
 
-.skuSelectorSubcontainer {
-  margin-bottom: 0;
-}
-
 @media only screen and (min-width: 640px) {
   .newsletter .container {
     padding: 140px;


### PR DESCRIPTION
#### What problem is this solving?

Use the API provided by SKU Selector to space variations.

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/classic-shoes/p

#### Checklist/Reminders

- [X] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [X] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [X] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
