### PR TITLE
Fix/remove split value for min items per page shelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `minItemsPerPage` prop in `shelf#home` block.
 
 ## [3.19.1] - 2019-12-03
 

--- a/store/blocks/home/home.jsonc
+++ b/store/blocks/home/home.jsonc
@@ -41,7 +41,7 @@
       "productList": {
         "maxItems": 10,
         "itemsPerPage": 5,
-        "minItemsPerPage": 1.5,
+        "minItemsPerPage": 1,
         "scroll": "BY_PAGE",
         "arrows": true,
         "titleText": "Top sellers"


### PR DESCRIPTION
#### What problem is this solving?

This should fix the issue with the weird sliding on the shelf on mobile.

#### How should this be manually tested?

Open this on mobile and see that the shelf 
[Workspace](https://fixshelfmobile--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and an overall reduction of technical debt -->
