### PR TITLE
Remove Carousel and Shelf in favor of list components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Removed
+### Changed
 - `vtex.carousel` in favor of using `list-context.image-list` and `slider-layout`.
 - `vtex.shelf` in favor of using `list-context.product-list` and `slider-layout`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Removed
+### Changed
 - `vtex.carousel` in favor of using `list-context.image-list` and `slider-layout`.
 - Custom implementation of `minicart.v2` in favor of the default one.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
+### Removed
 - `vtex.carousel` in favor of using `list-context.image-list` and `slider-layout`.
-- Custom implementation of `minicart.v2` in favor of the default one.
+- `vtex.shelf` in favor of using `list-context.product-list` and `slider-layout`.
 
 ## [3.24.0] - 2020-02-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- `vtex.carousel` in favor of using `list-context.image-list` and `slider-layout`.
+- Custom implementation of `minicart.v2` in favor of the default one.
 
 ## [3.24.0] - 2020-02-05
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -46,7 +46,9 @@
     "vtex.checkout-summary": "0.x",
     "vtex.product-list": "0.x",
     "vtex.add-to-cart-button": "0.x",
-    "vtex.product-bookmark-interfaces": "1.x"
+    "vtex.product-bookmark-interfaces": "1.x",
+    "vtex.slider-layout": "0.x",
+    "vtex.store-image": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/store/blocks/home/home.jsonc
+++ b/store/blocks/home/home.jsonc
@@ -14,6 +14,21 @@
     ]
   },
 
+  "shelf#home": {
+    "blocks": ["product-summary.shelf"]
+  },
+
+  "product-summary.shelf": {
+    "children": [
+      "product-summary-name",
+      "product-summary-description",
+      "product-summary-image",
+      "product-summary-price",
+      "product-summary-sku-selector",
+      "product-summary-buy-button"
+    ]
+  },
+
   "list-context.image-list#demo": {
     "children": ["slider-layout#demo-images"],
     "props": {

--- a/store/blocks/home/home.jsonc
+++ b/store/blocks/home/home.jsonc
@@ -67,7 +67,7 @@
         "phone": 1
       },
       "infinite": true,
-      "fullWidth": false,
+      "fullWidth": true,
       "blockClass": "shelf"
     }
   },

--- a/store/blocks/home/home.jsonc
+++ b/store/blocks/home/home.jsonc
@@ -1,7 +1,7 @@
 {
   "store.home": {
     "blocks": [
-      "carousel#home",
+      "list-context.image-list#demo",
       /* You can make references to blocks defined in other files.
        * For example, `flex-layout.row#deals` is defined in the `deals.json` file. */
       "flex-layout.row#deals",
@@ -13,10 +13,11 @@
     ]
   },
 
-  "carousel#home": {
+  "list-context.image-list#demo": {
+    "children": ["slider-layout#demo-images"],
     "props": {
-      "autoplay": false,
-      "banners": [
+      "height": 720,
+      "images": [
         {
           "image": "https://storecomponents.vteximg.com.br/arquivos/banner-principal.png",
           "mobileImage": "https://storecomponents.vteximg.com.br/arquivos/banner-principal-mobile.jpg"
@@ -25,10 +26,19 @@
           "image": "https://storecomponents.vteximg.com.br/arquivos/banner.jpg",
           "mobileImage": "https://storecomponents.vteximg.com.br/arquivos/banner-principal-mobile.jpg"
         }
-      ],
-      "height": 720,
-      "showArrows": true,
-      "showDots": true
+      ]
+    }
+  },
+  "slider-layout#demo-images": {
+    "props": {
+      "itemsPerPage": {
+        "desktop": 1,
+        "tablet": 1,
+        "phone": 1
+      },
+      "infinite": true,
+      "showNavigationArrows": "desktopOnly",
+      "fullWidth": true
     }
   },
 

--- a/store/blocks/home/home.jsonc
+++ b/store/blocks/home/home.jsonc
@@ -5,7 +5,8 @@
       /* You can make references to blocks defined in other files.
        * For example, `flex-layout.row#deals` is defined in the `deals.json` file. */
       "flex-layout.row#deals",
-      "shelf#home",
+      "rich-text#shelf-title",
+      "flex-layout.row#shelf",
       "info-card#home",
       "rich-text#question",
       "rich-text#link",
@@ -56,6 +57,33 @@
         "arrows": true,
         "titleText": "Top sellers"
       }
+    }
+  },
+
+  "rich-text#shelf-title": {
+    "props": {
+      "text": "## Summer",
+      "blockClass": "shelfTitle"
+    }
+  },
+  "flex-layout.row#shelf": {
+    "children": ["product-list-block#demo1"]
+  },
+  "product-list-block#demo1": {
+    "blocks": ["product-summary.shelf"],
+    "children": ["slider-layout#demo-products"],
+    "props": {
+      "orderBy": "OrderByTopSaleDESC"
+    }
+  },
+  "slider-layout#demo-products": {
+    "props": {
+      "itemsPerPage": {
+        "desktop": 5,
+        "tablet": 3,
+        "phone": 1
+      },
+      "infinite": true
     }
   },
 

--- a/store/blocks/home/home.jsonc
+++ b/store/blocks/home/home.jsonc
@@ -39,24 +39,7 @@
       },
       "infinite": true,
       "showNavigationArrows": "desktopOnly",
-      "fullWidth": true
-    }
-  },
-
-  "shelf#home": {
-    "blocks": ["product-summary.shelf"],
-    "props": {
-      "orderBy": "OrderByTopSaleDESC",
-      "paginationDotsVisibility": "desktopOnly",
-      "skusFilter": "FIRST_AVAILABLE",
-      "productList": {
-        "maxItems": 10,
-        "itemsPerPage": 5,
-        "minItemsPerPage": 1,
-        "scroll": "BY_PAGE",
-        "arrows": true,
-        "titleText": "Top sellers"
-      }
+      "blockClass": "carousel"
     }
   },
 
@@ -67,9 +50,9 @@
     }
   },
   "flex-layout.row#shelf": {
-    "children": ["product-list-block#demo1"]
+    "children": ["list-context.product-list#demo1"]
   },
-  "product-list-block#demo1": {
+  "list-context.product-list#demo1": {
     "blocks": ["product-summary.shelf"],
     "children": ["slider-layout#demo-products"],
     "props": {
@@ -83,29 +66,9 @@
         "tablet": 3,
         "phone": 1
       },
-      "infinite": true
-    }
-  },
-
-  "product-summary#home": {
-    "props": {
-      "isOneClickBuy": false,
-      "showBadge": true,
-      "badgeText": "OFF",
-      "buyButtonText": "Add to cart",
-      "displayBuyButton": "displayButtonAlways",
-      "showCollections": false,
-      "showListPrice": true,
-      "labelSellingPrice": "To",
-      "labelListPrice": "From",
-      "showLabels": true,
-      "showInstallments": true,
-      "showSavings": true,
-      "name": {
-        "showBrandName": true,
-        "showSku": true,
-        "showProductReference": true
-      }
+      "infinite": true,
+      "fullWidth": false,
+      "blockClass": "shelf"
     }
   },
 

--- a/styles/css/vtex.rich-text.css
+++ b/styles/css/vtex.rich-text.css
@@ -5,8 +5,13 @@
 }
 
 .container--shelfTitle {
-  text-align: center;
+  color: #727273;
   justify-content: center;
+  text-align: center;
+}
+
+.headingLevel2--shelfTitle {
+  font-weight: 200;
 }
 
 .container--deals .paragraph {

--- a/styles/css/vtex.rich-text.css
+++ b/styles/css/vtex.rich-text.css
@@ -4,6 +4,11 @@
   justify-content: center;
 }
 
+.container--shelfTitle {
+  text-align: center;
+  justify-content: center;
+}
+
 .container--deals .paragraph {
   margin: 0;
 }

--- a/styles/css/vtex.slider-layout.css
+++ b/styles/css/vtex.slider-layout.css
@@ -6,3 +6,13 @@
 .sliderTrackContainer {
   max-width: 1520px;
 }
+
+.layoutContainer {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  max-width: 96rem;
+}
+
+.slide {
+  margin-bottom: 25px;
+}

--- a/styles/css/vtex.slider-layout.css
+++ b/styles/css/vtex.slider-layout.css
@@ -9,6 +9,11 @@
   max-width: 1520px;
 }
 
+.paginationDotsContainer {
+  margin-top: .5rem;
+  margin-bottom: .5rem;
+}
+
 .layoutContainer--shelf {
   margin-top: 20px;
   margin-bottom: 20px;
@@ -17,4 +22,6 @@
 
 .slide--shelf {
   margin-bottom: 25px;
+  padding-left: .5rem;
+  padding-right: .5rem;
 }

--- a/styles/css/vtex.slider-layout.css
+++ b/styles/css/vtex.slider-layout.css
@@ -1,0 +1,8 @@
+.sliderLayoutContainer {
+  background-color: #F0F0F0;
+  justify-content: center;
+}
+
+.sliderTrackContainer {
+  max-width: 1520px;
+}

--- a/styles/css/vtex.slider-layout.css
+++ b/styles/css/vtex.slider-layout.css
@@ -1,18 +1,20 @@
 .sliderLayoutContainer {
-  background-color: #F0F0F0;
   justify-content: center;
+}
+.sliderLayoutContainer--carousel {
+  background-color: #F0F0F0;
 }
 
 .sliderTrackContainer {
   max-width: 1520px;
 }
 
-.layoutContainer {
+.layoutContainer--shelf {
   margin-top: 20px;
   margin-bottom: 20px;
   max-width: 96rem;
 }
 
-.slide {
+.slide--shelf {
   margin-bottom: 25px;
 }


### PR DESCRIPTION
#### What problem is this solving?

Our base Store Theme did not contain any examples on the use of `slider-layout` and was still using `vtex.carousel` in the home page. That would encourage users to keep using the carousel instead of using our composable solution of `list-contex.image-list` + `slider-layout`.

The same problem applies to the `shelf` block, which is now a `list-context.product-list` + `slider-layout`.

#### How should this be manually tested?

[Workspace](https://shelflayout--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

This depends on https://github.com/vtex-apps/product-summary/pull/229
