### PR TITLE
Fix search content layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Layout on search pages with few results but a big filter sidebar.
 
 ## [3.21.1] - 2019-12-27
 ### Fixed

--- a/store/blocks/search.jsonc
+++ b/store/blocks/search.jsonc
@@ -101,7 +101,8 @@
       "flex-layout.row#fetchmore"
     ],
     "props": {
-      "width": "grow"
+      "width": "grow",
+      "preventVerticalStretch": true
     }
   },
   "flex-layout.row#searchinfo": {


### PR DESCRIPTION
#### What problem is this solving?

Fixed search content layout when there weren't many products but the filter sidebar was long.

Before:
![image](https://user-images.githubusercontent.com/8443580/72931202-34b79500-3d3c-11ea-9dd5-62affc061230.png)

After:
![image](https://user-images.githubusercontent.com/8443580/72931109-0f2a8b80-3d3c-11ea-9e25-43c4320ebfb0.png)


#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/clothing?map=c,c,specificationFilter_52&query=/apparel---accessories/clothing/Black)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
