### PR TITLE
Remove custom implementation for minicart.v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use default `minicart.v2 from `vtex.minicart`.
 
 ## [3.23.0] - 2020-01-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Use default `minicart.v2 from `vtex.minicart`.
+- Use default `minicart.v2` from `vtex.minicart`.
 
 ## [3.23.0] - 2020-01-27
 ### Added

--- a/store/blocks/header/header.jsonc
+++ b/store/blocks/header/header.jsonc
@@ -105,31 +105,5 @@
       "url": "https://storecomponents.vteximg.com.br/arquivos/store-theme-logo-mobile.png",
       "width": "70"
     }
-  },
-
-  "minicart.v2": {
-    "children": ["minicart-base-content"]
-  },
-  "minicart-base-content": {
-    "blocks": ["minicart-product-list", "minicart-summary"]
-  },
-  "minicart-product-list": {
-    "blocks": ["product-list"]
-  },
-  "minicart-summary": {
-    "blocks": ["checkout-summary.compact"]
-  },
-
-  "checkout-summary.compact": {
-    "children": ["summary-totalizers#minicart"],
-    "props": {
-      "totalizersToShow": ["Items", "Discounts"]
-    }
-  },
-  "summary-totalizers#minicart": {
-    "props": {
-      "showTotal": true,
-      "showDeliveryTotal": false
-    }
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

Currently the `minicart.v2` used by `store-theme` is not using the default layout defined by `vtex.minicart`.

#### How should this be manually tested?

[Workspace](https://minicartchildren--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
