### PR TITLE
Add `height` on `product-summary-image`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `height` on `product-summary-image`
 
 ## [3.23.0] - 2020-01-27
 ### Added

--- a/store/blocks.jsonc
+++ b/store/blocks.jsonc
@@ -50,6 +50,12 @@
     ]
   },
 
+  "product-summary-image": {
+    "props": {
+      "height": 220
+    }
+  },
+
   "product-summary-specification-badges": {
     "props": {
       "specificationGroupName": "Group",


### PR DESCRIPTION
#### What problem is this solving?

Add `height` on `product-summary-image` so every image has the same dimension.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/clothing?map=c,c&order=OrderByReleaseDateDESC&query=/apparel---accessories/clothing)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/73780319-063eae80-476d-11ea-824a-5174505dee5b.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
