### PR TITLE
Refactor header to use native blocks and add some translucency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Refactor the `header` with native IO blocks.
+
+### Added
+- Animations to the `header` when it sticks to the top of the page.
 
 ## [3.25.0] - 2020-02-06
 ### Changed

--- a/store/blocks/header/header.jsonc
+++ b/store/blocks/header/header.jsonc
@@ -7,21 +7,21 @@
   },
   "header-layout.desktop": {
     "children": [
-      "header-row#1-desktop",
-      "header-row#2-desktop",
-      "header-row#3-desktop",
-      "header-row#4-desktop"
+      "flex-layout.row#1-desktop",
+      "flex-layout.row#2-desktop",
+      "flex-layout.row#3-desktop",
+      "sticky-layout.stack-container#4-desktop"
     ]
   },
 
-  "header-row#1-desktop": {
+  "flex-layout.row#1-desktop": {
     "children": ["telemarketing"],
     "props": {
       "fullWidth": true
     }
   },
 
-  "header-row#2-desktop": {
+  "flex-layout.row#2-desktop": {
     "children": ["notification.bar#home"],
     "props": {
       "fullWidth": "true"
@@ -32,32 +32,64 @@
       "content": "SELECTED ITEMS ON SALE! CHECK IT OUT!"
     }
   },
-  "header-row#3-desktop": {
-    "children": [
-      "vtex.menu@2.x:menu#websites",
-      "header-spacer",
-      "vtex.menu@2.x:menu#institutional"
-    ],
+  "flex-layout.row#3-desktop": {
     "props": {
       "blockClass": "menu-link",
-      "inverted": "true"
+      "horizontalAlign": "center",
+      "preventHorizontalStretch": true,
+      "preventVerticalStretch": true,
+      "fullWidth": true
+    },
+    "children": [
+      "vtex.menu@2.x:menu#websites",
+      "flex-layout.col#spacer",
+      "vtex.menu@2.x:menu#institutional"
+    ]
+  },
+  "flex-layout.col#spacer": {
+    "props": {
+      "width": "grow"
     }
   },
-  "header-row#4-desktop": {
+  "sticky-layout.stack-container#4-desktop": {
+    "children": ["sticky-layout#4-desktop"]
+  },
+  "sticky-layout#4-desktop": {
+    "props": {
+      "blockClass": "sticky-header"
+    },
+    "children": ["flex-layout.row#4-desktop"]
+  },
+  "flex-layout.row#4-desktop": {
+    "props": {
+      "blockClass": "main-header",
+      "horizontalAlign": "center",
+      "verticalAlign": "center",
+      "preventHorizontalStretch": true,
+      "preventVerticalStretch": true,
+      "fullWidth": true
+    },
     "children": [
-      "logo#desktop",
-      "vtex.menu@2.x:menu#category-menu",
-      "header-spacer",
-      "header-spacer",
+      "flex-layout.col#logo-desktop",
+      "flex-layout.col#category-menu",
+      "flex-layout.col#spacer",
       "search-bar",
       "locale-switcher",
       "login",
       "minicart.v2"
-    ],
+    ]
+  },
+  "flex-layout.col#logo-desktop": {
     "props": {
-      "sticky": true,
-      "blockClass": "main-header"
-    }
+      "verticalAlign": "middle"
+    },
+    "children": ["logo#desktop"]
+  },
+  "flex-layout.col#category-menu": {
+    "props": {
+      "verticalAlign": "middle"
+    },
+    "children": ["vtex.menu@2.x:menu#category-menu"]
   },
   "logo#desktop": {
     "props": {
@@ -68,19 +100,24 @@
     }
   },
   "header-layout.mobile": {
-    "children": ["header-row#1-mobile"]
+    "children": ["sticky-layout#1-mobile"]
   },
-  "header-row#1-mobile": {
+  "sticky-layout#1-mobile": {
+    "children": ["flex-layout.row#1-mobile"]
+  },
+  "flex-layout.row#1-mobile": {
     "children": [
       "drawer",
       "logo#mobile",
-      "header-spacer",
+      "flex-layout.col#spacer",
       "login",
       "minicart.v2"
     ],
     "props": {
-      "sticky": true,
-      "blockClass": "main-header-mobile"
+      "blockClass": "main-header-mobile",
+      "preventHorizontalStretch": true,
+      "preserveLayoutOnMobile": true,
+      "fullWidth": true
     }
   },
   "drawer": {

--- a/store/blocks/header/header.jsonc
+++ b/store/blocks/header/header.jsonc
@@ -10,7 +10,7 @@
       "flex-layout.row#1-desktop",
       "flex-layout.row#2-desktop",
       "flex-layout.row#3-desktop",
-      "sticky-layout.stack-container#4-desktop"
+      "sticky-layout#4-desktop"
     ]
   },
 
@@ -50,9 +50,6 @@
     "props": {
       "width": "grow"
     }
-  },
-  "sticky-layout.stack-container#4-desktop": {
-    "children": ["sticky-layout#4-desktop"]
   },
   "sticky-layout#4-desktop": {
     "props": {

--- a/styles/css/vtex.flex-layout.css
+++ b/styles/css/vtex.flex-layout.css
@@ -1,3 +1,45 @@
+.flexRowContent--menu-link,
+.flexRowContent--main-header {
+  padding: 0 0.5rem;
+}
+
+@media screen and (min-width: 40em) {
+  .flexRowContent--menu-link,
+  .flexRowContent--main-header {
+    padding: 0 1rem;
+  }
+}
+@media screen and (min-width: 80rem) {
+  .flexRowContent--menu-link,
+  .flexRowContent--main-header {
+    padding: 0 0.25rem;
+  }
+}
+
+.flexRowContent--menu-link {
+  background-color: #03044e;
+  color: #fff;
+}
+
+.flexRowContent--main-header {
+  background-color: #f0f0f0;
+}
+
+.flexRowContent--main-header-mobile {
+  align-items: center;
+  padding: 0.625rem 0.5rem;
+  background-color: #f0f0f0;
+}
+
+.flexRowContent--menu-link :global(.vtex-menu-2-x-styledLink) {
+  color: #ffffff;
+  font-size: 14px;
+}
+
+.flexRowContent--main-header :global(.vtex-menu-2-x-styledLink) {
+  color: #727273;
+  font-size: 14px;
+}
 .flexRow--deals {
   background-color: #a7afbd;
   padding: 14px 0px;

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -1,6 +1,6 @@
 .notificationBarContainer {
-  background-color: #E6F1E6;
-  color: #03034E;
+  background-color: #e6f1e6;
+  color: #03034e;
   font-weight: 700;
   font-size: 12px;
   text-decoration: underline;
@@ -13,12 +13,12 @@
 .infoCardContainer--info-card-home {
   max-width: 1520px;
   margin: 0 auto;
-  background-color: #E6F1E6;
+  background-color: #e6f1e6;
   padding: 0px;
 }
 
 .newsletter {
-  background-color: #03054E;
+  background-color: #03054e;
   max-width: 1528px;
   margin: 0 auto;
 }

--- a/styles/css/vtex.store-header.css
+++ b/styles/css/vtex.store-header.css
@@ -1,18 +1,66 @@
-.headerRow--menu-link :global(.vtex-menu-2-x-styledLink) {
-  color: #ffffff;
-  font-size: 14px;
+/* add transitions */
+:global(.vtex-sticky-layout-0-x-container) .logoLink,
+:global(.vtex-sticky-layout-0-x-container)
+  :global(.vtex-minicart-2-x-openIconContainer),
+:global(.vtex-sticky-layout-0-x-container)
+  :global(.vtex-store-components-3-x-searchBarContainer) {
+  transition: all 0.3s ease;
+  display: block;
 }
 
-.headerRow--main-header .headerRowBackground {
-  background-color: #F0F0F0;
+/* desktop/mobile main header padding and background transitions */
+:global(.vtex-flex-layout-0-x-flexRowContent--main-header),
+:global(.vtex-flex-layout-0-x-flexRowContent--main-header-mobile) {
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+  will-change: padding, background, box-shadow;
 }
 
-.headerRow--main-header :global(.vtex-menu-2-x-styledLink)  {
-  color: #727273;
-  font-size: 14px;
+/* main header desktop has a bigger padding when not stuck */
+:global(.vtex-flex-layout-0-x-flexRowContent--main-header) {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
 }
 
-.headerRow--main-header-mobile .headerRowBackground {
-  padding: 10px 0px;
-  background-color: #F0F0F0;
+/* add a box-shadow to desktop/mobile header when stuck */
+:global(.vtex-sticky-layout-0-x-wrapper--stuck)
+  :global(.vtex-flex-layout-0-x-flexRowContent--main-header),
+:global(.vtex-sticky-layout-0-x-wrapper--stuck)
+  :global(.vtex-flex-layout-0-x-flexRowContent--main-header-mobile) {
+  box-shadow: 0 4px 5px rgba(0, 0, 0, 0.1);
+}
+
+/* remove the extra padding when stuck from the desktop header */
+:global(.vtex-sticky-layout-0-x-wrapper--stuck)
+  :global(.vtex-flex-layout-0-x-flexRowContent--main-header) {
+  transition: background 0.3s ease, box-shadow 0.3s ease, padding 0.3s ease;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+/* if supported add some translucency to the desktop/mobile header background */
+@supports (backdrop-filter: blur(5px)) {
+  :global(.vtex-sticky-layout-0-x-wrapper--stuck)
+    :global(.vtex-flex-layout-0-x-flexRowContent--main-header),
+  :global(.vtex-sticky-layout-0-x-wrapper--stuck)
+    :global(.vtex-flex-layout-0-x-flexRowContent--main-header-mobile) {
+    backdrop-filter: blur(5px);
+  }
+
+  /* header background when stuck and not hovered */
+  :global(.vtex-sticky-layout-0-x-wrapper--stuck):not(:hover)
+    :global(.vtex-flex-layout-0-x-flexRowContent--main-header),
+  :global(.vtex-sticky-layout-0-x-wrapper--stuck):not(:hover)
+    :global(.vtex-flex-layout-0-x-flexRowContent--main-header-mobile) {
+    background: rgba(240, 240, 240, 0.8);
+  }
+}
+
+/* stick wrapper with the same color as the desktop/mobile header */
+:global(.vtex-sticky-layout-0-x-wrapper--sticky-header) {
+  background-color: #f0f0f0;
+}
+
+/* resize the logo for neat effect */
+:global(.vtex-sticky-layout-0-x-wrapper--stuck) .logoLink {
+  transform: scale(0.8);
 }

--- a/styles/css/vtex.store-header.css
+++ b/styles/css/vtex.store-header.css
@@ -11,7 +11,6 @@
 /* desktop/mobile main header padding and background transitions */
 :global(.vtex-flex-layout-0-x-flexRowContent--main-header),
 :global(.vtex-flex-layout-0-x-flexRowContent--main-header-mobile) {
-  transition: background 0.3s ease, box-shadow 0.3s ease;
   will-change: padding, background, box-shadow;
 }
 
@@ -29,10 +28,13 @@
   box-shadow: 0 4px 5px rgba(0, 0, 0, 0.1);
 }
 
-/* remove the extra padding when stuck from the desktop header */
+/*
+ * remove the extra padding when stuck from the desktop header
+ * we add a transition only when "stuck" for the "unstick" step seem faster
+ */
 :global(.vtex-sticky-layout-0-x-wrapper--stuck)
   :global(.vtex-flex-layout-0-x-flexRowContent--main-header) {
-  transition: background 0.3s ease, box-shadow 0.3s ease, padding 0.3s ease;
+  transition: padding 0.3s ease;
   padding-top: 0;
   padding-bottom: 0;
 }

--- a/styles/css/vtex.store-header.css
+++ b/styles/css/vtex.store-header.css
@@ -43,7 +43,7 @@
     :global(.vtex-flex-layout-0-x-flexRowContent--main-header),
   :global(.vtex-sticky-layout-0-x-wrapper--stuck)
     :global(.vtex-flex-layout-0-x-flexRowContent--main-header-mobile) {
-    backdrop-filter: blur(5px);
+    backdrop-filter: blur(8px);
   }
 
   /* header background when stuck and not hovered */


### PR DESCRIPTION
#### What problem is this solving?

This PR aims to refactor the model header of our theme. It uses the new sticky-layout and replaces the specific `header-row` and `header-spacer` blocks with native ones, such as `flex-layout`.

It also adds a gentle animation when the header sticks to the top of the page and makes it a little bit translucent.

#### How should this be manually tested?

Compare my [workspace](https://kiwi--storecomponents.myvtex.com/) with the [original one](http://storetheme.vtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12702016/74469060-adf96200-4e7a-11ea-8683-8007d1be5998.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
