### PR TITLE
Select search bar input instead of container and fix header animations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Limit the width of the search bar input instead of its container.
 
+### Fixed
+- Logo animation when header sticks to the top of the page.
+
+### Added
+- `prefers-reduced-motion` query to remove animation for users which don't want unnecessary animations.
+
 ## [3.26.0] - 2020-02-18
 ### Changed
 - Refactor the `header` with native IO blocks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Limit the width of the search bar input instead of its container.
 
 ## [3.26.0] - 2020-02-18
 ### Changed

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -6,8 +6,8 @@
   text-decoration: underline;
 }
 
-.searchBarContainer {
-  max-width: 265px;
+.searchBarContainer :global(.vtex-styleguide-9-x-input) {
+  max-width: 208px;
 }
 
 .infoCardContainer--info-card-home {

--- a/styles/css/vtex.store-header.css
+++ b/styles/css/vtex.store-header.css
@@ -1,5 +1,6 @@
 /* add transitions */
-:global(.vtex-sticky-layout-0-x-container) .logoLink,
+:global(.vtex-sticky-layout-0-x-container)
+  :global(.vtex-store-components-3-x-logoLink),
 :global(.vtex-sticky-layout-0-x-container)
   :global(.vtex-minicart-2-x-openIconContainer),
 :global(.vtex-sticky-layout-0-x-container)
@@ -11,7 +12,8 @@
 /* desktop/mobile main header padding and background transitions */
 :global(.vtex-flex-layout-0-x-flexRowContent--main-header),
 :global(.vtex-flex-layout-0-x-flexRowContent--main-header-mobile) {
-  will-change: padding, background, box-shadow;
+  transition: background 0.3s ease;
+  will-change: padding, background;
 }
 
 /* main header desktop has a bigger padding when not stuck */
@@ -34,7 +36,7 @@
  */
 :global(.vtex-sticky-layout-0-x-wrapper--stuck)
   :global(.vtex-flex-layout-0-x-flexRowContent--main-header) {
-  transition: padding 0.3s ease;
+  transition: padding 0.3s ease, background 0.3s ease;
   padding-top: 0;
   padding-bottom: 0;
 }
@@ -63,6 +65,20 @@
 }
 
 /* resize the logo for neat effect */
-:global(.vtex-sticky-layout-0-x-wrapper--stuck) .logoLink {
-  transform: scale(0.8);
+:global(.vtex-sticky-layout-0-x-wrapper--stuck)
+  :global(.vtex-store-components-3-x-logoLink) {
+  transform: scale(0.85);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :global(.vtex-sticky-layout-0-x-container)
+    :global(.vtex-store-components-3-x-logoLink),
+  :global(.vtex-sticky-layout-0-x-container)
+    :global(.vtex-minicart-2-x-openIconContainer),
+  :global(.vtex-sticky-layout-0-x-container)
+    :global(.vtex-store-components-3-x-searchBarContainer),
+  :global(.vtex-sticky-layout-0-x-wrapper--stuck)
+    :global(.vtex-flex-layout-0-x-flexRowContent--main-header) {
+    transition: none;
+  }
 }


### PR DESCRIPTION
#### What problem is this solving?

- Setting a `max-width` on the `searchBarContainer` breaks the layout on firefox. This PR changes this behavior to limiting the width of the actual input element.
- The logo wasn't being animated when the header got stuck.
- Removed animations for user with `prefers-reduced-motion`

Waiting for: https://github.com/vtex/styleguide/pull/1051

#### How should this be manually tested?

Check the search bars on this workspace in Firefox:
[Workspace](https://kiwisearch--storecomponents.myvtex.com/)

Compare with:
https://storetheme.vtex.com

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
