### PR TITLE
Remove action-primary and action-secondary colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove defintion for `action-primary` and `action-secondary` colors.
 
 ## [3.32.0] - 2020-03-20
 ### Changed

--- a/styles/configs/style.json
+++ b/styles/configs/style.json
@@ -57,8 +57,6 @@
         "background": {
           "base": "#ffffff",
           "base--inverted": "#03044e",
-          "action-primary": "#0F3E99",
-          "action-secondary": "#eef3f7",
           "emphasis": "#f71963",
           "disabled": "#f2f4f5",
           "success": "#8bc34a",
@@ -74,8 +72,6 @@
           "muted-5": "#f2f4f5"
         },
         "hover-background": {
-          "action-primary": "#072c75",
-          "action-secondary": "#dbe9fd",
           "emphasis": "#dd1659",
           "success": "#8bc34a",
           "success--faded": "#eafce3",
@@ -90,8 +86,6 @@
           "muted-5": "#f2f4f5"
         },
         "active-background": {
-          "action-primary": "#0c389f",
-          "action-secondary": "#dbe9fd",
           "emphasis": "#dd1659",
           "success": "#8bc34a",
           "success--faded": "#eafce3",
@@ -106,8 +100,6 @@
           "muted-5": "#f2f4f5"
         },
         "text": {
-          "action-primary": "#0F3E99",
-          "action-secondary": "#eef3f7",
           "link": "#0F3E99",
           "emphasis": "#f71963",
           "disabled": "#979899",
@@ -127,8 +119,6 @@
           "link": "#0c389f"
         },
         "hover-text": {
-          "action-primary": "#072c75",
-          "action-secondary": "#dbe9fd",
           "link": "#0c389f",
           "emphasis": "#dd1659",
           "success": "#8bc34a",
@@ -149,8 +139,6 @@
           "warning--faded": "#fff6e0"
         },
         "border": {
-          "action-primary": "#0F3E99",
-          "action-secondary": "#eef3f7",
           "emphasis": "#f71963",
           "disabled": "#e3e4e6",
           "success": "#8bc34a",
@@ -166,8 +154,6 @@
           "muted-5": "#f2f4f5"
         },
         "hover-border": {
-          "action-primary": "#072c75",
-          "action-secondary": "#dbe9fd",
           "emphasis": "#dd1659",
           "success": "#8bc34a",
           "success--faded": "#eafce3",
@@ -182,8 +168,6 @@
           "muted-5": "#f2f4f5"
         },
         "active-border": {
-          "action-primary": "#0c389f",
-          "action-secondary": "#dbe9fd",
           "emphasis": "#dd1659",
           "success": "#8bc34a",
           "success--faded": "#eafce3",
@@ -200,8 +184,6 @@
         "on": {
           "base": "#3f3f40",
           "base--inverted": "#ffffff",
-          "action-primary": "#ffffff",
-          "action-secondary": "#0F3E99",
           "emphasis": "#ffffff",
           "disabled": "#979899",
           "success": "#ffffff",
@@ -217,8 +199,6 @@
           "muted-5": "#3f3f40"
         },
         "hover-on": {
-          "action-primary": "#ffffff",
-          "action-secondary": "#0F3E99",
           "emphasis": "#ffffff",
           "success": "#ffffff",
           "success--faded": "#3f3f40",
@@ -228,8 +208,6 @@
           "warning--faded": "#1a1a1a"
         },
         "active-on": {
-          "action-primary": "#ffffff",
-          "action-secondary": "#0F3E99",
           "emphasis": "#ffffff",
           "success": "#ffffff",
           "success--faded": "#3f3f40",

--- a/styles/css/vtex.flex-layout.css
+++ b/styles/css/vtex.flex-layout.css
@@ -17,7 +17,7 @@
 }
 
 .flexRowContent--menu-link {
-  background-color: #03044e;
+  background-color: #0c389f;
   color: #fff;
 }
 

--- a/styles/css/vtex.rich-text.css
+++ b/styles/css/vtex.rich-text.css
@@ -31,7 +31,7 @@
   max-width: 540px;
   margin: 0 16px;
   padding-top: 120px;
-  color: #03034E;
+  color: #0c389f;
 }
 
 .container--question .strong {
@@ -45,7 +45,7 @@
   max-width: 540px;
   padding-top: 36px;
   padding-bottom: 84px;
-  color: #03034E;
+  color: #0c389f;
 }
 
 .container--link .strong {
@@ -58,11 +58,11 @@
   text-decoration: none;
   font-size: 36px;
   font-weight: 300;
-  color: #03034E;
+  color: #0c389f;
 }
 
 .container--title {
-  color: #03034E;
+  color: #0c389f;
   font-size: 28px;
   font-weight: 700;
 }
@@ -78,7 +78,7 @@
   }
 
   .container--title {
-    color: #03034E;
+    color: #0c389f;
     font-size: 40px;
     font-weight: 700;
     max-width: 60%;

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -1,6 +1,6 @@
 .notificationBarContainer {
   background-color: #e6f1e6;
-  color: #03034e;
+  color: #0c389f;
   font-weight: 700;
   font-size: 12px;
   text-decoration: underline;
@@ -18,7 +18,7 @@
 }
 
 .newsletter {
-  background-color: #03054e;
+  background-color: #0c389f;
   max-width: 1528px;
   margin: 0 auto;
 }


### PR DESCRIPTION
#### What problem is this solving?
Removes the aforementioned colors from `styles.json` and replaces them by the default values of the colors in the customizations.

#### How should this be manually tested?
[Workspace](https://lucas--checkoutio.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

- ##### Home
![image](https://user-images.githubusercontent.com/10223856/77424801-7acabc80-6db0-11ea-8ffe-82714a6a1361.png)

- ##### PDP
![image](https://user-images.githubusercontent.com/10223856/77424974-bfeeee80-6db0-11ea-9640-1753c84e9b16.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
✔️ | Something else