### PR TITLE
Add new `vtex.product-price` blocks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Price blocks on `product-summary` and on the PDP to use the new blocks from `vtex.product-price`
+- Product title style on PDP.
 
 ## [3.32.0] - 2020-03-20
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -52,7 +52,8 @@
     "vtex.store-icons": "0.x",
     "vtex.modal-layout": "0.x",
     "vtex.store-link": "0.x",
-    "vtex.product-gifts": "0.x"
+    "vtex.product-gifts": "0.x",
+    "vtex.product-price": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,7 @@
     "vtex.stack-layout": "0.x",
     "vtex.product-specification-badges": "0.x",
     "vtex.product-review-interfaces": "1.x",
+    "vtex.reviews-and-ratings": "1.x",
     "vtex.telemarketing": "2.x",
     "vtex.order-placed": "1.x",
     "vtex.checkout-summary": "0.x",

--- a/manifest.json
+++ b/manifest.json
@@ -54,7 +54,7 @@
     "vtex.modal-layout": "0.x",
     "vtex.store-link": "0.x",
     "vtex.product-gifts": "0.x",
-    "vtex.product-price": "0.x"
+    "vtex.product-price": "1.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/store/blocks.jsonc
+++ b/store/blocks.jsonc
@@ -51,7 +51,8 @@
 
   "product-summary-image#shelf": {
     "props": {
-      "showBadge": false
+      "showBadge": false,
+      "height": 300
     }
   },
   "stack-layout#prodsum": {

--- a/store/blocks.jsonc
+++ b/store/blocks.jsonc
@@ -51,15 +51,13 @@
 
   "product-summary-image#shelf": {
     "props": {
-      "showBadge": false,
-      "height": 300
+      "showBadge": false
     }
   },
   "stack-layout#prodsum": {
     "children": [
       "product-summary-image#shelf",
       "modal-trigger#quickview"
-      
     ]
   },
 

--- a/store/blocks.jsonc
+++ b/store/blocks.jsonc
@@ -42,8 +42,46 @@
       "product-summary-name",
       "product-rating-inline",
       "product-summary-space",
-      "product-summary-price",
+      "product-list-price#summary",
+      "flex-layout.row#selling-price-savings",
+      "product-installments#summary",
       "add-to-cart-button"
+    ]
+  },
+  "product-list-price#summary": {
+    "props": {
+      "blockClass": "summary"
+    }
+  },
+  "product-installments#summary": {
+    "props": {
+      "blockClass": "summary"
+    }
+  },
+  "product-selling-price#summary": {
+    "props": {
+      "blockClass": "summary"
+    }
+  },
+  "product-price-savings#summary": {
+    "props": {
+      "markers": [
+        "discount"
+      ],
+      "blockClass": "summary"
+    }
+  },
+  "flex-layout.row#selling-price-savings": {
+    "props": {
+      "colGap": 2,
+      "fullWidth": true,
+      "preserveLayoutOnMobile": true,
+      "horizontalAlign": "center",
+      "preventHorizontalStretch": true
+    },
+    "children": [
+      "product-selling-price#summary",
+      "product-price-savings#summary"
     ]
   },
   "product-summary-image#shelf": {

--- a/store/blocks.jsonc
+++ b/store/blocks.jsonc
@@ -48,42 +48,7 @@
       "add-to-cart-button"
     ]
   },
-  "product-list-price#summary": {
-    "props": {
-      "blockClass": "summary"
-    }
-  },
-  "product-installments#summary": {
-    "props": {
-      "blockClass": "summary"
-    }
-  },
-  "product-selling-price#summary": {
-    "props": {
-      "blockClass": "summary"
-    }
-  },
-  "product-price-savings#summary": {
-    "props": {
-      "markers": [
-        "discount"
-      ],
-      "blockClass": "summary"
-    }
-  },
-  "flex-layout.row#selling-price-savings": {
-    "props": {
-      "colGap": 2,
-      "fullWidth": true,
-      "preserveLayoutOnMobile": true,
-      "horizontalAlign": "center",
-      "preventHorizontalStretch": true
-    },
-    "children": [
-      "product-selling-price#summary",
-      "product-price-savings#summary"
-    ]
-  },
+
   "product-summary-image#shelf": {
     "props": {
       "showBadge": false

--- a/store/blocks/home/home.jsonc
+++ b/store/blocks/home/home.jsonc
@@ -72,7 +72,7 @@
         "phone": 1
       },
       "infinite": true,
-      "fullWidth": true,
+      "fullWidth": false,
       "blockClass": "shelf"
     }
   },

--- a/store/blocks/price.jsonc
+++ b/store/blocks/price.jsonc
@@ -1,0 +1,50 @@
+{
+  "product-list-price#summary": {
+    "props": {
+      "blockClass": "summary"
+    }
+  },
+  "product-installments#summary": {
+    "props": {
+      "blockClass": "summary"
+    }
+  },
+  "product-selling-price#summary": {
+    "props": {
+      "blockClass": "summary"
+    }
+  },
+  "product-price-savings#summary": {
+    "props": {
+      "markers": [
+        "discount"
+      ],
+      "blockClass": "summary"
+    }
+  },
+  "flex-layout.row#selling-price-savings": {
+    "props": {
+      "colGap": 2,
+      "fullWidth": true,
+      "preserveLayoutOnMobile": true,
+      "horizontalAlign": "center",
+      "preventHorizontalStretch": true
+    },
+    "children": [
+      "product-selling-price#summary",
+      "product-price-savings#summary"
+    ]
+  },
+
+  "flex-layout.row#list-price-savings": {
+    "props": {
+      "colGap": 2,
+      "preserveLayoutOnMobile": true,
+      "preventHorizontalStretch": true
+    },
+    "children": [
+      "product-list-price",
+      "product-price-savings"
+    ]
+  }
+}

--- a/store/blocks/price.jsonc
+++ b/store/blocks/price.jsonc
@@ -22,13 +22,23 @@
       "blockClass": "summary"
     }
   },
+  "flex-layout.row#selling-price": {
+    "props": {
+      "colGap": 2,
+      "preserveLayoutOnMobile": true,
+      "preventHorizontalStretch": true,
+      "marginBottom": 3
+    },
+    "children": [
+      "product-selling-price"
+    ]
+  },
   "flex-layout.row#selling-price-savings": {
     "props": {
       "colGap": 2,
-      "fullWidth": true,
       "preserveLayoutOnMobile": true,
-      "horizontalAlign": "center",
-      "preventHorizontalStretch": true
+      "preventHorizontalStretch": true,
+      "marginBottom": 3
     },
     "children": [
       "product-selling-price#summary",
@@ -40,7 +50,9 @@
     "props": {
       "colGap": 2,
       "preserveLayoutOnMobile": true,
-      "preventHorizontalStretch": true
+      "preventHorizontalStretch": true,
+      "marginBottom": 2,
+      "marginTop": 5
     },
     "children": [
       "product-list-price",

--- a/store/blocks/price.jsonc
+++ b/store/blocks/price.jsonc
@@ -27,7 +27,7 @@
       "colGap": 2,
       "preserveLayoutOnMobile": true,
       "preventHorizontalStretch": true,
-      "marginBottom": 3
+      "marginBottom": 4
     },
     "children": [
       "product-selling-price"
@@ -38,7 +38,7 @@
       "colGap": 2,
       "preserveLayoutOnMobile": true,
       "preventHorizontalStretch": true,
-      "marginBottom": 3
+      "marginBottom": 4
     },
     "children": [
       "product-selling-price#summary",

--- a/store/blocks/product.jsonc
+++ b/store/blocks/product.jsonc
@@ -81,7 +81,7 @@
       "vtex.store-components:product-name",
       "product-rating-summary",
       "flex-layout.row#list-price-savings",
-      "product-selling-price",
+      "flex-layout.row#selling-price",
       "product-installments",
       "product-separator",
       "product-identifier.product",

--- a/store/blocks/product.jsonc
+++ b/store/blocks/product.jsonc
@@ -80,7 +80,9 @@
     "children": [
       "vtex.store-components:product-name",
       "product-rating-summary",
-      "product-price#product-details",
+      "flex-layout.row#list-price-savings",
+      "product-selling-price",
+      "product-installments",
       "product-separator",
       "product-identifier.product",
       "sku-selector",
@@ -91,6 +93,18 @@
       "availability-subscriber",
       "shipping-simulator",
       "share#default"
+    ]
+  },
+
+  "flex-layout.row#list-price-savings": {
+    "props": {
+      "colGap": 2,
+      "preserveLayoutOnMobile": true,
+      "preventHorizontalStretch": true
+    },
+    "children": [
+      "product-list-price",
+      "product-price-savings"
     ]
   },
 

--- a/store/blocks/product.jsonc
+++ b/store/blocks/product.jsonc
@@ -96,18 +96,6 @@
     ]
   },
 
-  "flex-layout.row#list-price-savings": {
-    "props": {
-      "colGap": 2,
-      "preserveLayoutOnMobile": true,
-      "preventHorizontalStretch": true
-    },
-    "children": [
-      "product-list-price",
-      "product-price-savings"
-    ]
-  },
-
   "sku-selector": {
     "props": {
       "variationsSpacing": 3,

--- a/store/blocks/quickview.json
+++ b/store/blocks/quickview.json
@@ -37,7 +37,7 @@
   "flex-layout.col#quickviewPrice": {
     "children": [
       "flex-layout.row#list-price-savings",
-      "product-selling-price",
+      "flex-layout.row#selling-price",
       "product-installments"
     ]
   },

--- a/store/blocks/quickview.json
+++ b/store/blocks/quickview.json
@@ -27,12 +27,19 @@
   "modal-content#quickview": {
     "children": [
       "vtex.store-components:product-name",
-      "product-price",
+      "flex-layout.col#quickviewPrice",
       "product-summary-sku-selector#quickview"
     ],
     "props": {
       "blockClass": "quickviewContent"
     }
+  },
+  "flex-layout.col#quickviewPrice": {
+    "children": [
+      "flex-layout.row#list-price-savings",
+      "product-selling-price",
+      "product-installments"
+    ]
   },
   "modal-actions#quickview": {
     "props": {

--- a/styles/css/vtex.product-price.css
+++ b/styles/css/vtex.product-price.css
@@ -15,6 +15,7 @@
 
 .installments {
   color: #3f3f40;
+  margin-bottom: 1rem;
 }
 
 .savings {
@@ -44,7 +45,7 @@
 }
 
 .listPrice--summary {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
 }
 
 .installments--summary {

--- a/styles/css/vtex.product-price.css
+++ b/styles/css/vtex.product-price.css
@@ -1,0 +1,44 @@
+.listPrice {
+  color: #979899;
+  margin-bottom: .25rem;
+}
+
+.sellingPrice {
+  color: #3f3f40;
+  font-size: 1.25rem;
+}
+
+.sellingPriceValue {
+  font-size: 2.25rem;
+  font-weight: 700;
+}
+
+.installments {
+  color: #3f3f40;
+}
+
+.savings {
+  font-weight: 500;
+  color: #79B03A;
+}
+
+.sellingPriceValue--summary {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #2E2E2E;
+}
+
+.savings--summary {
+  background: #8BC34A;
+  border-radius: 1000px;
+  align-items: center;
+  display: flex;
+}
+
+.savings-discount--summary {
+  font-size: 0.9rem;
+  vertical-align: baseline;
+  color: #FFFFFF;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}

--- a/styles/css/vtex.product-price.css
+++ b/styles/css/vtex.product-price.css
@@ -42,3 +42,11 @@
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 }
+
+.listPrice--summary {
+  margin-bottom: 0.5rem;
+}
+
+.installments--summary {
+  margin-bottom: 2rem;
+}

--- a/styles/css/vtex.product-summary.css
+++ b/styles/css/vtex.product-summary.css
@@ -19,6 +19,8 @@
 
 .nameContainer {
   justify-content: start;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
 }
 
 .brandName {
@@ -29,4 +31,8 @@
 
 .container {
   text-align: start;
+}
+
+.imageContainer {
+  text-align: center;
 }

--- a/styles/css/vtex.product-summary.css
+++ b/styles/css/vtex.product-summary.css
@@ -18,7 +18,7 @@
 }
 
 .nameContainer {
-  justify-content: left;
+  justify-content: start;
 }
 
 .brandName {

--- a/styles/css/vtex.product-summary.css
+++ b/styles/css/vtex.product-summary.css
@@ -16,3 +16,17 @@
     display: none;
   } 
 }
+
+.nameContainer {
+  justify-content: left;
+}
+
+.brandName {
+  font-weight: 600;
+  font-size: 18px;
+  color: #2E2E2E;
+}
+
+.container {
+  text-align: start;
+}

--- a/styles/css/vtex.reviews-and-ratings.css
+++ b/styles/css/vtex.reviews-and-ratings.css
@@ -1,6 +1,6 @@
 .inlineContainer {
   margin-left: 0rem ;
-  margin-bottom: 0.5rem;
+  margin-bottom: 3rem;
 }
 
 .star--filled {

--- a/styles/css/vtex.reviews-and-ratings.css
+++ b/styles/css/vtex.reviews-and-ratings.css
@@ -1,0 +1,12 @@
+.inlineContainer {
+  margin-left: 0rem ;
+  margin-bottom: 0.5rem;
+}
+
+.star--filled {
+  color: #FFB100;
+}
+
+.star--empty {
+  color: #FFB100;
+}

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -111,5 +111,6 @@
 }
 
 .productNameContainer {
+  color: #3f3f40;
   font-weight: bold;
 }

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -113,4 +113,5 @@
 .productNameContainer {
   color: #3f3f40;
   font-weight: bold;
+  font-size: 30px;
 }


### PR DESCRIPTION
#### What problem is this solving?

As the title says. You can see the difference in PDP and on the product summaries.
⚠️**THIS SHOULD NOT BE MERGED UNTIL I BUMP THE `vtex.product-price` VERSION TO 1.X ON THE MANIFEST!**
🔴I SHOULD MAKE THE NECESSARY CHANGES ON SITE-EDITOR WHEN THIS IS MERGED SO EVERY PRODUCT SUMMARY IS HOW IT IS IN THE WORKSPACE'S SHELF

#### How should this be manually tested?

[Workspace](https://productprice--storecomponents.myvtex.com/)

#### Screenshots or example usage
PDP
![image](https://user-images.githubusercontent.com/8443580/77687292-ec576600-6f7c-11ea-856b-52df40af880c.png)

Shelf
![image](https://user-images.githubusercontent.com/8443580/77687379-0ee97f00-6f7d-11ea-99bf-cae52206725c.png)

Detailed screenshot
![image](https://user-images.githubusercontent.com/8443580/77692675-d5694180-6f85-11ea-8690-49db5be24b3d.png)
