### PR TITLE
Set `preventRouteChange` to `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- PreventRouteChange to `false`.
 
 ## [3.36.0] - 2020-05-11
 ### Added

--- a/store/blocks/search.jsonc
+++ b/store/blocks/search.jsonc
@@ -68,7 +68,7 @@
     ],
     "props": {
       "pagination": "show-more",
-      "preventRouteChange": true,
+      "preventRouteChange": false,
       "mobileLayout": {
         "mode1": "small",
         "mode2": "normal"


### PR DESCRIPTION
#### What problem is this solving?

Set `preventRouteChange` to false so our test store can have the new URL format. The side effect of this decision is that without `preventRouteChange`, every facet selection will trigger a page reload.

#### How should this be manually tested?

https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/clothing/color_White
Check that the URL is better

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
