### PR TITLE
Update README to correct docs URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.37.1] - 2020-07-08
+### Changed
+- Change URL of the docs in README
+
 ## [3.37.0] - 2020-05-18
 ### Changed
 - PreventRouteChange to `false`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.37.1] - 2020-07-08
 ### Changed
 - Change URL of the docs in README
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Our boilerplate theme to create stores in the VTEX IO platform.
 ![store-theme-default](https://user-images.githubusercontent.com/1354492/63937047-e8d81c80-ca37-11e9-86fc-61e88847bbfb.png)
 
 ## Tutorial
-To understand how things work check our tutorial [Build a store using VTEX IO](https://vtex.io/docs/getting-started/build-stores-with-vtex-io/1)
+To understand how things work check our tutorial [Build a store using VTEX IO](https://vtex.io/docs/getting-started/build-stores-with-store-framework/1/)
 
 ## Dependencies
 All store components that you see on this document are open source too. Production ready, you can found those apps in this GitHub organization.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-theme",
-  "version": "3.37.0",
+  "version": "3.37.1",
   "builders": {
     "styles": "2.x",
     "store": "0.x",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-theme",
-  "version": "3.37.1",
+  "version": "3.37.0",
   "builders": {
     "styles": "2.x",
     "store": "0.x",


### PR DESCRIPTION
The old URL of [Build a store using VTEX IO] go to 404 page, I changed to the new one that I supposed that is the right one (https://vtex.io/docs/getting-started/build-stores-with-store-framework/1/).

#### What problem is this solving?

Update the readme to point to the right location in docs.

#### How to test it?

Just click the new link.


