### PR TITLE
Fix active action-secondary bg and border colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Active **background** `action-secondary` color from `#dbe9fd` to `#d2defc`
+- Active **border** `action-secondary` color from `#dbe9fd` to `#d2defc`
 
 ## [3.37.1] - 2020-07-08
 

--- a/styles/configs/style.json
+++ b/styles/configs/style.json
@@ -91,7 +91,7 @@
         },
         "active-background": {
           "action-primary": "#0c389f",
-          "action-secondary": "#dbe9fd",
+          "action-secondary": "#d2defc",
           "emphasis": "#dd1659",
           "success": "#8bc34a",
           "success--faded": "#eafce3",
@@ -183,7 +183,7 @@
         },
         "active-border": {
           "action-primary": "#0c389f",
-          "action-secondary": "#dbe9fd",
+          "action-secondary": "#d2defc",
           "emphasis": "#dd1659",
           "success": "#8bc34a",
           "success--faded": "#eafce3",


### PR DESCRIPTION
#### What problem is this solving?

Those colors are out of sync with Figma (from `#dbe9fd` to `#d2defc`).

See https://github.com/vtex-apps/place-components/pull/21#discussion_r462546314.

The changes are the same as https://github.com/vtex/vtex-tachyons/pull/32.

#### How to test it?

I don't know, as no component use those classnames, but I suppose testing this won't be necessary. It does not break anything though -> [workspace](https://style--storecomponents.myvtex.com/).

#### How does this PR make you feel?

<img src="https://user-images.githubusercontent.com/26108090/88934792-6cf1e000-d257-11ea-94bb-aff0b4b9096f.png" width="300" />