### PR TITLE
Remove unnecessary 'icon-cart' definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `icon-cart` being bigger than it should.
 
 ## [3.39.0] - 2020-09-30
 ### Added

--- a/store/blocks/minicart.jsonc
+++ b/store/blocks/minicart.jsonc
@@ -7,15 +7,8 @@
 
   "minicart.v2": {
     "props": {
-      "customPixelEventName": "addToCart",
-      "MinicartIcon": "icon-cart#minicart-icon"
+      "customPixelEventName": "addToCart"
     },
     "children": ["minicart-base-content"]
-  },
-
-  "icon-cart#minicart-icon": {
-    "props": {
-      "size": 24
-    }
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

This definition for `icon-cart` is not necessary and was causing the minicart icon to be too big.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://victormiranda--storecomponents.myvtex.com/)

#### Screenshots or example usage:

**Before**

<img width="277" alt="Screen Shot 2020-10-02 at 15 24 40" src="https://user-images.githubusercontent.com/27777263/94956974-65eb8600-04c3-11eb-8662-bd29f0840c17.png">

**After**
<img width="269" alt="Screen Shot 2020-10-02 at 15 24 25" src="https://user-images.githubusercontent.com/27777263/94956987-6a17a380-04c3-11eb-8ad7-b6bcfa615b20.png">

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/GDnomdqpSHlIs/giphy.gif)
