### PR TITLE
Prevent minicart opening itself on ALL addToCart events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `minicart.v2` opening itself on **all** `addToCart` events, including the ones triggered by quantity changes in the checkout cart.
 
 ## [3.39.1] - 2020-10-05
 ### Fixed

--- a/store/blocks/minicart.jsonc
+++ b/store/blocks/minicart.jsonc
@@ -1,13 +1,14 @@
 {
   "add-to-cart-button": {
     "props": {
-      "addToCartFeedback": "customEvent"
+      "addToCartFeedback": "customEvent",
+      "customPixelEventId": "add-to-cart-button"
     }
   },
 
   "minicart.v2": {
     "props": {
-      "customPixelEventName": "addToCart"
+      "customPixelEventId": "add-to-cart-button"
     },
     "children": ["minicart-base-content"]
   }


### PR DESCRIPTION
#### What problem is this solving?

The current behavior causes the `minicart.v2` drawer to open even when users are just changing the quantity for an item that is already in the cart.

This was reported by the @vtex-apps/checkout-ui team, and can be reproduced by interacting with the `quantity-selector` at: https://checkoutio.myvtex.com/cart/add?sku=289.

#### How to test it?

1. Go to this [Workspace](https://victormiranda--checkoutio.myvtex.com/cart).
2. Add a product to the cart and you should see the `minicart.v2` drawer open itself.
3. Click the `Go to checkout` button and go to `/cart`.
4. Update the quantity of this item, now the `minicart.v2` should not open.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/ftrPtuqQUIZ5opePYS/giphy.gif)
