### PR TITLE
Adding video block example to about us page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+Example of [vtex.store-video](https://github.com/vtex-apps/store-video) usage.
 
 ## [4.1.0] - 2020-11-16
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-Example of [vtex.store-video](https://github.com/vtex-apps/store-video) usage.
+- Example of [vtex.store-video](https://github.com/vtex-apps/store-video) usage.
 
 ## [4.1.0] - 2020-11-16
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -52,6 +52,7 @@
     "vtex.store-icons": "0.x",
     "vtex.modal-layout": "0.x",
     "vtex.store-link": "0.x",
+    "vtex.store-video": "1.x",
     "vtex.product-gifts": "0.x",
     "vtex.product-price": "1.x",
     "vtex.disclosure-layout": "1.x",

--- a/store/blocks/about-us.json
+++ b/store/blocks/about-us.json
@@ -1,13 +1,14 @@
 {
   "store.custom#about-us": {
     "blocks": [
-      "flex-layout.row#about-us"
+      "flex-layout.row#about-us",
+      "video#about-us"
     ]
   },
 
   "flex-layout.row#about-us": {
     "children": [
-      "slider-layout#about-us",
+      "image#mobile-phone",
       "flex-layout.col#text-about-us"
     ]
   },
@@ -31,21 +32,6 @@
     }
   },
 
-  "slider-layout#about-us": {
-    "props": {
-      "itemsPerPage": {
-        "desktop": 1,
-        "tablet": 1,
-        "phone": 1
-      },
-      "infinite": true,
-      "showNavigationArrows": "desktopOnly"
-    },
-    "children": [
-      "image#mobile-phone",
-      "video#about-us"
-    ]
-  },
   "image#mobile-phone": {
     "props": {
       "src": "https://storecomponents.vteximg.com.br/arquivos/mobile-phone.png",

--- a/store/blocks/about-us.json
+++ b/store/blocks/about-us.json
@@ -7,7 +7,7 @@
 
   "flex-layout.row#about-us": {
     "children": [
-      "image#mobile-phone",
+      "slider-layout#about-us",
       "flex-layout.col#text-about-us"
     ]
   },
@@ -31,6 +31,21 @@
     }
   },
 
+  "slider-layout#about-us": {
+    "props": {
+      "itemsPerPage": {
+        "desktop": 1,
+        "tablet": 1,
+        "phone": 1
+      },
+      "infinite": true,
+      "showNavigationArrows": "desktopOnly"
+    },
+    "children": [
+      "image#mobile-phone",
+      "video#about-us"
+    ]
+  },
   "image#mobile-phone": {
     "props": {
       "src": "https://storecomponents.vteximg.com.br/arquivos/mobile-phone.png",
@@ -39,7 +54,13 @@
       "blockClass": "storePrint"
     }
   },
-
+  "video#about-us": {
+    "props": {
+      "src": "https://www.youtube.com/embed/JgkrlaF52WQ",
+      "width": "100%",
+      "height": "100%"
+    }
+  },
   "rich-text#about-us": {
     "props": {
       "text": "**Optimized store framework** \n Free your front-end with our React + Node store framework. Improve usability and SEO, while driving more conversion with modular components, single page applications, and a ready-for-PWA structure. \n **Multi-currency and language** \n Go international with multiple storefronts to support different languages and easily manage local currencies and payment conditions. \n **Serverless development platform** \n Reduce loading time, improve usability, and make the best out of SEO. Developing scalable components with a comprehensive, easy-to-use toolset, you can build stores faster than ever.",

--- a/styles/css/vtex.store-video.css
+++ b/styles/css/vtex.store-video.css
@@ -1,0 +1,6 @@
+.videoContainer {
+  width: 95%;
+  height: 54%;
+  display: flex;
+  justify-content: center;
+}

--- a/styles/css/vtex.store-video.css
+++ b/styles/css/vtex.store-video.css
@@ -1,6 +1,11 @@
 .videoContainer {
-  width: 95%;
-  height: 54%;
-  display: flex;
-  justify-content: center;
+  width: 100%;
+  height: 300px;
+  margin-top: 2%;
+}
+
+@media only screen and (min-width: 640px) {
+  .videoContainer {
+    height: 700px;
+  }
 }


### PR DESCRIPTION
#### What problem is this solving?

This PR adds an example of video block usage to the about us page.

#### How to test it?

It's the second slide on the [about us](https://icarovideoblock--storecomponents.myvtex.com/about-us) page.

#### Screenshots or example usage:

<img width="780" alt="Screen Shot 2020-11-16 at 1 59 15 PM" src="https://user-images.githubusercontent.com/8127610/99283548-ec5dec00-2813-11eb-84f2-3a3f4071d67d.png">

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/iHOwdoVuWD4Bi/giphy.gif)
