### PR TITLE
Remove unnecessary max-width definition of search-bar block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Unnecessary `max-width` style in the input of `search-bar` block which causes the style to break when the `search-bar` needs to be bigger`.
 
 ## [4.2.0] - 2020-11-30
 ### Added

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -6,10 +6,6 @@
   text-decoration: underline;
 }
 
-.searchBarContainer :global(.vtex-styleguide-9-x-input) {
-  max-width: 208px;
-}
-
 .infoCardContainer--info-card-home {
   max-width: 1520px;
   margin: 0 auto;


### PR DESCRIPTION
#### What problem is this solving?

When the `search-bar` is in a place that gives more space to grow it breaks the position of the right icon of the block. 

#### How to test it?

[Workspace](https://virtual404--storecomponents.myvtex.com/default-404)

1. It shouldn't break the current layout of the search-bar

#### Screenshots or example usage:

Before
![image](https://user-images.githubusercontent.com/8517023/101781438-927cd900-3ad6-11eb-92c6-56292e527463.png)

Now
![image](https://user-images.githubusercontent.com/8517023/101781534-b3452e80-3ad6-11eb-998c-b7a2345febb0.png)


#### Describe alternatives you've considered if any.

We could also try to position the icon correctly, but this would make the input smaller than space and the remaining area that would like the input would be just an empty space
![image](https://user-images.githubusercontent.com/8517023/101781745-f901f700-3ad6-11eb-83c1-7fbc74167738.png)


#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

This gif has nothing to do with this PR, I just liked it.
![](https://media.giphy.com/media/lVBtp4SRW6rvDHf1b6/giphy.gif)
