### PR TITLE
Fix subject to conditional layout

### DIFF
--- a/store/blocks/pdp/product.jsonc
+++ b/store/blocks/pdp/product.jsonc
@@ -37,7 +37,7 @@
     "props": {
       "conditions": [
         {
-          "subject": "isProductAvailability"
+          "subject": "isProductAvailable"
         }
       ],
       "Then": "flex-layout.row#product-main",


### PR DESCRIPTION
#### What problem is this solving?
Basically the conditional-layout subject was being passed incorrectly... The correct thing is to use "isProductAvailable"

<!--- What is the motivation and context for this change? -->
This was breaking the price display on the product page.

#### How to test it?
https://testsssssss--avantivtexio.myvtex.com/jaqueta-biker/p

#### Screenshots or example usage:
![image](https://user-images.githubusercontent.com/32168339/124175330-dbe94180-da83-11eb-9041-b7c7e43918ee.png)
![image](https://user-images.githubusercontent.com/32168339/124175564-22d73700-da84-11eb-8dfb-5c1cc0fc8925.png)

Thanks,
![image](https://user-images.githubusercontent.com/32168339/124175454-0509d200-da84-11eb-9967-754e3a089fca.png)

