### PR TITLE
Update reviews-and-ratings peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `vtex.reviews-and-ratings` peer dependency from `2.x` t0 `3.x`
+
 ## [4.4.2] - 2021-07-02
 ### Fixed
 - Wrong condition subject being used in `condition-layout` example.

--- a/manifest.json
+++ b/manifest.json
@@ -65,7 +65,7 @@
     "vtex.css-handles": "1.x"
   },
   "peerDependencies": {
-    "vtex.reviews-and-ratings": "2.x"
+    "vtex.reviews-and-ratings": "3.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }


### PR DESCRIPTION
#### What problem is this solving?

The latest version of `vtex.reviews-and-ratings` is `3.x`, which includes many improvements and fixes unavailable on `2.x`. We would like to encourage new stores to start with this version.

#### How to test it?

New version linked here: https://reviews3--storecomponents.myvtex.com/
